### PR TITLE
Fix DbContext namespace

### DIFF
--- a/Api/DvrTimeSheetContext.cs
+++ b/Api/DvrTimeSheetContext.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using TimesheetApi.Domain.Entities;
 
-namespace TimesheetApi;
+namespace TimesheetApi.Domain;
 
 public partial class DvrTimeSheetContext : DbContext
 {


### PR DESCRIPTION
## Summary
- update `DvrTimeSheetContext` namespace to `TimesheetApi.Domain`

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688c9b70491c8323a106ccec321e2df5