### PR TITLE
Add TypeScript configuration for frontend

### DIFF
--- a/Front/tsconfig.json
+++ b/Front/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add tsconfig for React front-end with strict ESNext settings

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688e7bda1fd08323aecb97f5f3d2eba0