### PR TITLE
Add React plugin configuration for Vite

### DIFF
--- a/Front/package.json
+++ b/Front/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "typescript": "^5.2.2",
-    "vite": "^4.4.9"
+    "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^4.2.0"
   }
 }

--- a/Front/vite.config.ts
+++ b/Front/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+export default defineConfig({ plugins: [react()] });


### PR DESCRIPTION
## Summary
- configure Vite to use React via `@vitejs/plugin-react`.

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm test` *(fails: Missing script: "test")*
- `npm run dev` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_688e7bd6a2a08323a3cf8530de91cc91