### PR TITLE
feat: allow CORS for frontend

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -54,6 +54,9 @@ builder.Services.AddScoped<UbicacionOficinasDiveriumService>();
 builder.Services.AddScoped<UbicacioneService>();
 builder.Services.AddScoped<UserService>();
 
+builder.Services.AddCors(o => o.AddPolicy("AllowFrontend", p =>
+    p.WithOrigins("http://localhost:5173").AllowAnyHeader().AllowAnyMethod()));
+
 
 var app = builder.Build();
 
@@ -65,6 +68,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors("AllowFrontend");
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- allow frontend at http://localhost:5173 to access API via new CORS policy

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e7bd66af48323afb4487d6abf6a3c