### PR TITLE
feat(frontend): make API URL configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Desktop.ini
 appsettings.Development.json
 appsettings.Local.json
 secrets.json
+Front/.env
 
 ## Logs de Serilog
 *.log

--- a/Front/src/api/axios.ts
+++ b/Front/src/api/axios.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+const baseURL = import.meta.env.VITE_API_URL || 'http://localhost:5244/api';
+
 const api = axios.create({
-  baseURL: 'https://localhost:7225/api',
+  baseURL,
 });
 
 export default api;

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Este proyecto incluye un archivo `.gitignore` adaptado para Visual Studio y .NET
 
 ---
 
+## 🌐 Configuración del Frontend
+
+Para conectar el frontend de React con la API, crea un archivo `.env` dentro de la carpeta `Front` con el contenido:
+```env
+VITE_API_URL=https://localhost:7225/api
+```
+Si no se establece, se usará `http://localhost:5244/api` por defecto.
+
 ## ✅ Roadmap
 
 - [x] Configuración base del proyecto


### PR DESCRIPTION
## Summary
- read API base URL from `import.meta.env.VITE_API_URL` with fallback
- ignore front-end `.env` and document variable setup

## Testing
- `npm run build` *(fails: You installed esbuild for another platform than the one you're currently using)*
- `dotnet test` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e7bd52ba88323acd7241d5f952e87