### PR TITLE
Make API base URL configurable in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ Desktop.ini
 appsettings.Development.json
 appsettings.Local.json
 secrets.json
-Front/.env
 
 ## Logs de Serilog
 *.log

--- a/Front/.env
+++ b/Front/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://localhost:7225/api

--- a/Front/src/api/axios.ts
+++ b/Front/src/api/axios.ts
@@ -2,7 +2,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL, // desde el .env
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'https://localhost:7225/api'
 });
 
 export default api;


### PR DESCRIPTION
## Summary
- Read API base URL from `VITE_API_BASE_URL` with fallback to `https://localhost:7225/api`
- Add `.env` file with `VITE_API_BASE_URL` and allow it to be tracked

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: `vite` Permission denied)


------
https://chatgpt.com/codex/tasks/task_e_6891ee0e02248323862690da81e65224