### PR TITLE
fix: include api prefix in proyecto service endpoints

### DIFF
--- a/Front/src/services/proyectoService.ts
+++ b/Front/src/services/proyectoService.ts
@@ -2,24 +2,24 @@ import api from '../api/axios';
 import { Proyecto } from '../types/Proyecto';
 
 export const getProyectos = async () => {
-  const response = await api.get<Proyecto[]>('/Proyectos');
+  const response = await api.get<Proyecto[]>('/api/Proyectos');
   return response.data;
 };
 
 export const getProyecto = async (id: number) => {
-  const response = await api.get<Proyecto>(`/Proyectos/${id}`);
+  const response = await api.get<Proyecto>(`/api/Proyectos/${id}`);
   return response.data;
 };
 
 export const createProyecto = async (proyecto: Omit<Proyecto, 'idProyecto'>) => {
-  const response = await api.post<Proyecto>('/Proyectos', proyecto);
+  const response = await api.post<Proyecto>('/api/Proyectos', proyecto);
   return response.data;
 };
 
 export const updateProyecto = async (id: number, proyecto: Proyecto) => {
-  await api.put(`/Proyectos/${id}`, proyecto);
+  await api.put(`/api/Proyectos/${id}`, proyecto);
 };
 
 export const deleteProyecto = async (id: number) => {
-  await api.delete(`/Proyectos/${id}`);
+  await api.delete(`/api/Proyectos/${id}`);
 };


### PR DESCRIPTION
## Summary
- ensure all Proyecto service calls use `/api/Proyectos` paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6891ee0df8008323835fe4d74c858f13