### PR TITLE
Fix line chart card layout

### DIFF
--- a/Front/src/pages/Home.tsx
+++ b/Front/src/pages/Home.tsx
@@ -197,23 +197,24 @@ export default function Home() {
       <Grid container spacing={2}>
         <Grid item xs={12} md={7}>
           <CardSoft sx={{ height: 360 }}>
-            <Stack
-              direction="row"
-              alignItems="center"
-              justifyContent="space-between"
-              mb={1.5}
-            >
-              <Typography variant="subtitle2" color="text.secondary">
-                Reports
-              </Typography>
-              <IconButton size="small">
-                <MoreVertIcon fontSize="small" />
-              </IconButton>
-            </Stack>
+            <Stack sx={{ height: "100%" }}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                mb={1.5}
+              >
+                <Typography variant="subtitle2" color="text.secondary">
+                  Reports
+                </Typography>
+                <IconButton size="small">
+                  <MoreVertIcon fontSize="small" />
+                </IconButton>
+              </Stack>
 
-            <Box sx={{ height: "85%" }}>
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={lineData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+              <Box sx={{ flexGrow: 1 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={lineData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
                   <defs>
                     <linearGradient id="lineBlue" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="0%" stopColor="#6366F1" stopOpacity={0.9} />
@@ -248,6 +249,7 @@ export default function Home() {
                 </LineChart>
               </ResponsiveContainer>
             </Box>
+          </Stack>
           </CardSoft>
         </Grid>
 


### PR DESCRIPTION
## Summary
- ensure line chart card fills available height and exposes explicit chart height

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node node_modules/vite/bin/vite.js build`


------
https://chatgpt.com/codex/tasks/task_e_68a0fc3742888323bd80a49e0c8b8613