### PR TITLE
Incorpora IDs de tecnologías y recursos al guardar proyectos

### DIFF
--- a/Front/src/pages/Proyectos/ProyectoDialog.tsx
+++ b/Front/src/pages/Proyectos/ProyectoDialog.tsx
@@ -24,8 +24,8 @@ export default function ProyectoDialog({ open, onClose, initial, onSaved }: Prop
   const [descripcion, setDescripcion] = useState(initial?.descripcion ?? "");
 
   // selección
-  const [tecSel, setTecSel] = useState<Tecnologia[]>(initial?.tecnologias ?? []);
-  const [recSel, setRecSel] = useState<Recurso[]>(initial?.recursos ?? []);
+  const [tecSel, setTecSel] = useState<Tecnologia[]>([]);
+  const [recSel, setRecSel] = useState<Recurso[]>([]);
 
   // catálogos
   const [tecOptions, setTecOptions] = useState<Tecnologia[]>([]);
@@ -40,18 +40,25 @@ export default function ProyectoDialog({ open, onClose, initial, onSaved }: Prop
       .then(([tecs, recs]) => {
         setTecOptions(tecs);
         setRecOptions(recs);
-        // si viene edit y sólo tenías ids, resolvélos acá si querés
+
+        if (initial) {
+          const selTecs = initial.tecnologiaIds
+            ? tecs.filter((t) => initial.tecnologiaIds!.includes(t.idTecnologia))
+            : initial.tecnologias ?? [];
+          const selRecs = initial.recursoIds
+            ? recs.filter((r) => initial.recursoIds!.includes(r.idRecurso))
+            : initial.recursos ?? [];
+          setTecSel(selTecs);
+          setRecSel(selRecs);
+        } else {
+          setTecSel([]);
+          setRecSel([]);
+        }
+
+        setNombre(initial?.nombre ?? "");
+        setDescripcion(initial?.descripcion ?? "");
       })
       .finally(() => setLoading(false));
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    // rehidratamos campos al abrir con `initial`
-    setNombre(initial?.nombre ?? "");
-    setDescripcion(initial?.descripcion ?? "");
-    setTecSel(initial?.tecnologias ?? []);
-    setRecSel(initial?.recursos ?? []);
   }, [open, initial]);
 
   const tecnologiaIds = useMemo(() => tecSel.map(t => t.idTecnologia), [tecSel]);

--- a/Front/src/services/proyectoService.ts
+++ b/Front/src/services/proyectoService.ts
@@ -13,13 +13,25 @@ export const getProyecto = async (id: number) => {
 };
 
 // ESTRATEGIA A: mandar ids dentro del DTO
-export const createProyecto = async (proyecto: Omit<Proyecto, "idProyecto">) => {
-  const r = await api.post<Proyecto>("/api/Proyectos", proyecto);
+export const createProyecto = async (
+  proyecto: Omit<Proyecto, "idProyecto">
+) => {
+  const payload = {
+    ...proyecto,
+    tecnologiaIds: proyecto.tecnologiaIds ?? [],
+    recursoIds: proyecto.recursoIds ?? [],
+  };
+  const r = await api.post<Proyecto>("/api/Proyectos", payload);
   return r.data;
 };
 
 export const updateProyecto = async (id: number, proyecto: Proyecto) => {
-  await api.put(`/api/Proyectos/${id}`, proyecto);
+  const payload = {
+    ...proyecto,
+    tecnologiaIds: proyecto.tecnologiaIds ?? [],
+    recursoIds: proyecto.recursoIds ?? [],
+  };
+  await api.put(`/api/Proyectos/${id}`, payload);
 };
 
 export const deleteProyecto = async (id: number) => {


### PR DESCRIPTION
## Summary
- Agrega `tecnologiaIds` y `recursoIds` al payload de creación y edición de proyectos
- Rehidrata y envía las listas de IDs en el diálogo de proyectos

## Testing
- `npm run build` *(fails: [vite] Rollup failed to resolve import "@fontsource-variable/inter" from src/main.tsx)*
- `curl -X POST http://localhost:3000/api/Proyectos -H 'Content-Type: application/json' -d '{"nombre":"test","tecnologiaIds":[1],"recursoIds":[2]}'` *(fails: Couldn't connect to server)*
- `curl -X PUT http://localhost:3000/api/Proyectos/1 -H 'Content-Type: application/json' -d '{"idProyecto":1,"nombre":"test","tecnologiaIds":[1],"recursoIds":[2]}'` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68b1907bdc008323a92bc855d4c9533d