### PR TITLE
feat: extend project dto with resource and technology ids

### DIFF
--- a/Api/Controllers/ProyectosController.cs
+++ b/Api/Controllers/ProyectosController.cs
@@ -1,6 +1,4 @@
-using TimesheetApi.Domain;
-using TimesheetApi.Domain.Entities;
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using TimesheetApi.Application.DTOs;
 using TimesheetApi.Application.Services;
 
@@ -28,6 +26,13 @@ public class ProyectosController : ControllerBase
     public async Task<IActionResult> GetById(int id)
     {
         var result = await _service.GetByIdAsync(id);
+        return result == null ? NotFound() : Ok(result);
+    }
+
+    [HttpGet("{id}/detalle")]
+    public async Task<IActionResult> GetDetalle(int id)
+    {
+        var result = await _service.GetDetalleAsync(id);
         return result == null ? NotFound() : Ok(result);
     }
 

--- a/Api/DTOs/ProyectoDto.cs
+++ b/Api/DTOs/ProyectoDto.cs
@@ -1,4 +1,6 @@
-﻿// Application/DTOs/ProyectoDto.cs
+// Application/DTOs/ProyectoDto.cs
+using System.Collections.Generic;
+
 namespace TimesheetApi.Application.DTOs;
 
 public class ProyectoDto
@@ -8,5 +10,6 @@ public class ProyectoDto
     public string? Descripcion { get; set; }
     public DateTime? FechaAlta { get; set; }
     public DateTime? FechaCierre { get; set; }
+    public List<int>? IdTecnologias { get; set; }
+    public List<int>? IdRecursos { get; set; }
 }
-

--- a/Api/Mappings/ProyectoProfile.cs
+++ b/Api/Mappings/ProyectoProfile.cs
@@ -1,5 +1,6 @@
-﻿// Application/Mappings/ProyectoProfile.cs
+// Application/Mappings/ProyectoProfile.cs
 using AutoMapper;
+using System.Linq;
 using TimesheetApi.Application.DTOs;
 using TimesheetApi.Domain.Entities;
 
@@ -9,6 +10,9 @@ public class ProyectoProfile : Profile
 {
     public ProyectoProfile()
     {
-        CreateMap<Proyecto, ProyectoDto>().ReverseMap();
+        CreateMap<Proyecto, ProyectoDto>()
+            .ForMember(d => d.IdRecursos, opt => opt.MapFrom(s => s.ResourceToProjects.Select(r => r.ResourceId)))
+            .ReverseMap()
+            .ForMember(d => d.ResourceToProjects, opt => opt.Ignore());
     }
 }

--- a/Api/Services/ProyectoService.cs
+++ b/Api/Services/ProyectoService.cs
@@ -1,12 +1,111 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using TimesheetApi.Domain;
 using TimesheetApi.Domain.Entities;
 using TimesheetApi.Application.DTOs;
 using AutoMapper;
+using System.Linq;
 
 namespace TimesheetApi.Application.Services;
 
 public class ProyectoService : CrudService<Proyecto, ProyectoDto>
 {
     public ProyectoService(DvrTimeSheetContext context, IMapper mapper) : base(context, mapper) { }
+
+    public new async Task<ProyectoDto> CreateAsync(ProyectoDto dto)
+    {
+        var entity = _mapper.Map<Proyecto>(dto);
+        _context.Proyectos.Add(entity);
+        await _context.SaveChangesAsync();
+
+        if (dto.IdRecursos != null)
+        {
+            foreach (var recursoId in dto.IdRecursos)
+            {
+                _context.ResourceToProjects.Add(new ResourceToProject
+                {
+                    ProjectId = entity.IdProyecto,
+                    ResourceId = recursoId
+                });
+            }
+        }
+
+        if (dto.IdTecnologias != null)
+        {
+            foreach (var tecnologiaId in dto.IdTecnologias)
+            {
+                _context.ProyectosTecnologias.Add(new ProyectosTecnologia
+                {
+                    IdProyecto = entity.IdProyecto,
+                    IdTecnologia = tecnologiaId
+                });
+            }
+        }
+
+        await _context.SaveChangesAsync();
+        return _mapper.Map<ProyectoDto>(entity);
+    }
+
+    public new async Task<bool> UpdateAsync(int id, ProyectoDto dto)
+    {
+        var entity = await _context.Proyectos
+            .Include(p => p.ResourceToProjects)
+            .FirstOrDefaultAsync(p => p.IdProyecto == id);
+        if (entity == null) return false;
+
+        _mapper.Map(dto, entity);
+
+        if (dto.IdRecursos != null)
+        {
+            var existingResourceIds = entity.ResourceToProjects.Select(r => r.ResourceId).ToList();
+            var toAdd = dto.IdRecursos.Except(existingResourceIds);
+            var toRemove = existingResourceIds.Except(dto.IdRecursos);
+
+            _context.ResourceToProjects.RemoveRange(entity.ResourceToProjects.Where(r => toRemove.Contains(r.ResourceId)));
+            foreach (var recursoId in toAdd)
+            {
+                entity.ResourceToProjects.Add(new ResourceToProject
+                {
+                    ProjectId = id,
+                    ResourceId = recursoId
+                });
+            }
+        }
+
+        if (dto.IdTecnologias != null)
+        {
+            var existingTecnologias = await _context.ProyectosTecnologias.Where(t => t.IdProyecto == id).ToListAsync();
+            var existingTecnologiaIds = existingTecnologias.Select(t => t.IdTecnologia).ToList();
+            var toAdd = dto.IdTecnologias.Except(existingTecnologiaIds);
+            var toRemove = existingTecnologiaIds.Except(dto.IdTecnologias);
+
+            _context.ProyectosTecnologias.RemoveRange(existingTecnologias.Where(t => toRemove.Contains(t.IdTecnologia)));
+            foreach (var tecnologiaId in toAdd)
+            {
+                _context.ProyectosTecnologias.Add(new ProyectosTecnologia
+                {
+                    IdProyecto = id,
+                    IdTecnologia = tecnologiaId
+                });
+            }
+        }
+
+        await _context.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<ProyectoDto?> GetDetalleAsync(int id)
+    {
+        var proyecto = await _context.Proyectos
+            .Include(p => p.ResourceToProjects)
+            .FirstOrDefaultAsync(p => p.IdProyecto == id);
+        if (proyecto == null) return null;
+
+        var dto = _mapper.Map<ProyectoDto>(proyecto);
+        dto.IdRecursos = proyecto.ResourceToProjects.Select(r => r.ResourceId).ToList();
+        dto.IdTecnologias = await _context.ProyectosTecnologias
+            .Where(t => t.IdProyecto == id)
+            .Select(t => t.IdTecnologia)
+            .ToListAsync();
+        return dto;
+    }
 }

--- a/Api/Validators/ProyectoDtoValidator.cs
+++ b/Api/Validators/ProyectoDtoValidator.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using TimesheetApi.Application.DTOs;
 
 namespace TimesheetApi.Application.Validators;
@@ -21,5 +21,11 @@ public class ProyectoDtoValidator : AbstractValidator<ProyectoDto>
             .GreaterThanOrEqualTo(x => x.FechaAlta.GetValueOrDefault())
             .When(x => x.FechaCierre.HasValue && x.FechaAlta.HasValue)
             .WithMessage("La fecha de cierre no puede ser anterior a la fecha de alta");
+
+        RuleFor(x => x.IdTecnologias)
+            .NotNull().WithMessage("Las tecnologías son obligatorias");
+
+        RuleFor(x => x.IdRecursos)
+            .NotNull().WithMessage("Los recursos son obligatorios");
     }
 }


### PR DESCRIPTION
## Summary
- include resource and technology id lists on project DTO
- validate that provided resource and technology collections are not null
- expose project detail endpoint returning associated resource and technology ids

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1907c5f288323b4e177cce906c924